### PR TITLE
Removed references of Hotwire in HTMX specific project.

### DIFF
--- a/htmx-spring-boot/htmx-spring-boot/src/main/java/de/odrotbohm/spring/htmx/webmvc/Htmx.java
+++ b/htmx-spring-boot/htmx-spring-boot/src/main/java/de/odrotbohm/spring/htmx/webmvc/Htmx.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import org.springframework.web.servlet.View;
 
 /**
- * API to conveniently create and render Hotwire {@link HtmxPartials}.
+ * API to conveniently create and render HTMX {@link HtmxPartials}.
  *
  * @author Oliver Drotbohm
  */

--- a/htmx-spring-boot/htmx-spring-boot/src/main/java/de/odrotbohm/spring/htmx/webmvc/WebMvcHtmx.java
+++ b/htmx-spring-boot/htmx-spring-boot/src/main/java/de/odrotbohm/spring/htmx/webmvc/WebMvcHtmx.java
@@ -35,7 +35,7 @@ import org.thymeleaf.spring5.SpringTemplateEngine;
 import org.thymeleaf.templatemode.TemplateMode;
 
 /**
- * API to conveniently build Hotwire streams.
+ * API to conveniently build SSE streams.
  *
  * @author Oliver Drotbohm
  */

--- a/htmx-spring-boot/readme.adoc
+++ b/htmx-spring-boot/readme.adoc
@@ -1,6 +1,6 @@
 = Spring Boot HTMX integration
 
-https://htmx.org/[Hotwire] can be used just fine with Spring Boot out of the box.
+https://htmx.org/[HTMX] can be used just fine with Spring Boot out of the box.
 However, as a couple of examples have shown, it usually requires a bit of boilerplate code to be written on the server side.
 This library attempts to remove that boilerplate code by providing a few Spring MVC extensions that make it easy to use Thymeleaf templates and template fragments as HTMX partials that allow updating multiple parts of an UI selectively.
 


### PR DESCRIPTION
Thank you for this Spring/HTMX work. Following my comment https://twitter.com/odrotbohm/status/1459122852116971531 - I've replaced the Hotwire references to point to HTMX instead.